### PR TITLE
Move try block to catch decrypt() error with no text  embed() in image

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,8 @@ const digUp = (imageFileOrBuffer, password) => {
           _clone,
         });
         const payloadText = buffer.toString('utf8');
-        const modifiedPayloadText = password ? decrypt(payloadText, password) : payloadText;
         try {
+          const modifiedPayloadText = password ? decrypt(payloadText, password) : payloadText;
           const payload = JSON.parse(modifiedPayloadText);
         
           const textBuffer = Buffer.from(payload.text, 'utf8');
@@ -48,7 +48,7 @@ const digUp = (imageFileOrBuffer, password) => {
           }
         }
         catch (err) {
-          console.log({ modifiedPayloadText });
+          //console.log({ modifiedPayloadText });
           reject(new Error('Could not decrypt message'));
         }
       } else {


### PR DESCRIPTION
Corrected as outlined in issue #1.

Moved the try block up a line.

Commented out the console.log on line 51 as it throws an error in this case.